### PR TITLE
Add liveness and readiness probes

### DIFF
--- a/openshift-templates/selenium-deployment.yaml
+++ b/openshift-templates/selenium-deployment.yaml
@@ -61,6 +61,26 @@ objects:
             protocol: TCP
           - containerPort: 8778
             protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 4444
+              scheme: HTTP
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 4444
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -127,12 +147,28 @@ objects:
           imagePullPolicy: Always
           name: selenium-node-chrome
           ports:
-          - containerPort: 8080
+          - containerPort: 5555
             protocol: TCP
-          - containerPort: 8443
-            protocol: TCP
-          - containerPort: 8778
-            protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -198,12 +234,28 @@ objects:
           imagePullPolicy: Always
           name: selenium-node-chrome-debug
           ports:
-          - containerPort: 8080
+          - containerPort: 5555
             protocol: TCP
-          - containerPort: 8443
-            protocol: TCP
-          - containerPort: 8778
-            protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -270,12 +322,28 @@ objects:
           imagePullPolicy: Always
           name: selenium-node-firefox
           ports:
-          - containerPort: 8080
+          - containerPort: 5555
             protocol: TCP
-          - containerPort: 8443
-            protocol: TCP
-          - containerPort: 8778
-            protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -343,12 +411,28 @@ objects:
           imagePullPolicy: Always
           name: selenium-node-firefox-debug
           ports:
-          - containerPort: 8080
+          - containerPort: 5555
             protocol: TCP
-          - containerPort: 8443
-            protocol: TCP
-          - containerPort: 8778
-            protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/selenium-node-base/Dockerfile
+++ b/selenium-node-base/Dockerfile
@@ -62,4 +62,6 @@ RUN mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
 
 USER 1001
 
+EXPOSE 5555
+
 ENTRYPOINT ["/opt/bin/start-selenium-node.sh"]


### PR DESCRIPTION
Resolves #1 - Exposes port 5555 for all nodes in the Grid and enables liveness/readiness probes in the deployment configurations.